### PR TITLE
clean fix

### DIFF
--- a/src/Mindy/Validation/Traits/ValidateObject.php
+++ b/src/Mindy/Validation/Traits/ValidateObject.php
@@ -46,11 +46,11 @@ trait ValidateObject
                     $this->cleanedData[$name] = $value;
                     $field->setValue($value);
                 }
-            }
 
-            if ($field->isValid() === false) {
-                foreach ($field->getErrors() as $error) {
-                    $this->addError($name, $error);
+                if ($this->hasErrors() !== false) {
+                    foreach ($field->getErrors() as $error) {
+                        $this->addError($name, $error);
+                    }
                 }
             }
 


### PR DESCRIPTION
Валидация формы. Проблема при использовании clean* методов в форме.

Перебор полей формы, выполнение метода isValid() - внутри него очищаются ошибки, перебираются валидаторы, поле валидируется. Всё корректно. Затем выполняется метод clean*, внутри него происходит вызов $this->addErrors(), который добавляет ошибки в поле. Затем снова вызывается метод isValid(), который **очищает** ошибки из поля и затем говорит, что всё хорошо.